### PR TITLE
#10, #11 корректировка цен ранних паровозов

### DIFF
--- a/src/steam/a.pnml
+++ b/src/steam/a.pnml
@@ -104,7 +104,7 @@ hint_change_after(steam_a, 1875)
 item (FEAT_TRAINS, steam_a, 736) {
   property {
     name: string(STR_NAME_A_A);
-    vehicle_dates(1861, 1872, 25, 15, 2, 10)
+    vehicle_dates(1861, 1872, 25, 15, 2, 2)
     vehicle_pass()
     vehicle_steam(250, 31+20, 20.0)
   }

--- a/src/steam/d-schneider.pnml
+++ b/src/steam/d-schneider.pnml
@@ -37,7 +37,7 @@ hint_engine_with_subtype(d_schneider,
 item (FEAT_TRAINS, d_schneider, 580) {
   property {
     name: string(STR_NAME_D_SCHNEIDER);
-    vehicle_dates(1867, 1877, 40, 10, 3, 2)
+    vehicle_dates(1867, 1877, 40, 10, 3, 3)
     vehicle_pass()
     vehicle_steam(400, 31+20, 39.0)
   }

--- a/src/steam/dk.pnml
+++ b/src/steam/dk.pnml
@@ -16,17 +16,17 @@ steamer_direction_template(steam_dk, _sprites_start)
 long_vehicle(steam_dk)
 
 switch (FEAT_TRAINS, SELF, steam_dk_running_cost_factor,
-[  STORE_TEMP(151 - 14 * (build_year >= 1875), 0),  // Моторы
-   STORE_TEMP(21 - 2 * (build_year >= 1875), 1),    // Бригада
-   STORE_TEMP(53 - 5 * (build_year >= 1875), 2),    // Износ
+[  STORE_TEMP(26 + 4 * (build_year >= 1875), 0),   // Моторы
+   STORE_TEMP(4, 1),                               // Бригада
+   STORE_TEMP(12 + 2 * (build_year >= 1875), 2),    // Износ
    STORE_TEMP(0, 3),                                // Сопровождение
-   STORE_TEMP(37 - 3 * (build_year >= 1875), 4),    // ТО
-   STORE_TEMP(3, 5),                                // Сертификация
+   STORE_TEMP(10 - 2 * (build_year >= 1875), 4),    // ТО
+   STORE_TEMP(1, 5),                                // Сертификация
 
    STORE_TEMP(82 - 7 * (build_year >= 1875), 6),       // Скорость
    STORE_TEMP(33 + 20 - 2 * (build_year >= 1875), 7),  // Тара
    STORE_TEMP(LOAD_TEMP(7), 8)])                       // Максимальная масса
-{ all_running_cost_factor; }                           // 189
+{ all_running_cost_factor; }                           // 53 + 8
 
 engine_tender(steam_dk)
 engine_tender_length(steam_dk, 4, 1, 2, 1)

--- a/src/steam/dk.pnml
+++ b/src/steam/dk.pnml
@@ -31,8 +31,8 @@ switch (FEAT_TRAINS, SELF, steam_dk_running_cost_factor,
 engine_tender(steam_dk)
 engine_tender_length(steam_dk, 4, 1, 2, 1)
 engine_steam_1_effect(steam_dk_create_effect, -3, 10)
-engine_cost_change_build_after(steam_dk, 6,
-                                         7, 1875)
+engine_cost_change_build_after(steam_dk, 3,
+                                         4, 1875)
 engine_speed_change_build_after(steam_dk, 82,
                                           75, 1875)
 engine_weight_change_build_after(steam_dk, 33+20,
@@ -57,7 +57,7 @@ hint_change_after(steam_dk, 1875)
 item (FEAT_TRAINS, steam_dk, 735) {
   property {
     name: string(STR_NAME_DK);
-    vehicle_dates(1870, 1880, 35, 10, 4, 6)
+    vehicle_dates(1870, 1880, 35, 10, 4, 3)
     vehicle_pass()
     vehicle_steam(300, 33+20, 30.0)
   }


### PR DESCRIPTION
Вроде привел в соотвествие с таблицей.
Прошу проверить.

Новые значения.

А: 
цена: $7 392

Дк: 
Цена: $10 817 > (с 1875) > $11 829
СО: $1 741 > (с 1875) > $1 903